### PR TITLE
User-settable IP for fqdn entry fixes #73

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,7 @@ class hosts (
   $enable_fqdn_entry     = true,
   $use_fqdn              = true,
   $fqdn_host_aliases     = $::hostname,
-  $fqdn_ip               = $::ipaddress
+  $fqdn_ip               = $::ipaddress,
   $localhost_aliases     = ['localhost',
                             'localhost4',
                             'localhost4.localdomain4'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,7 @@ class hosts (
   $enable_fqdn_entry     = true,
   $use_fqdn              = true,
   $fqdn_host_aliases     = $::hostname,
+  $fqdn_ip               = $::ipaddress
   $localhost_aliases     = ['localhost',
                             'localhost4',
                             'localhost4.localdomain4'],
@@ -94,11 +95,9 @@ class hosts (
   if $fqdn_entry_enabled == true {
     $fqdn_ensure          = 'present'
     $my_fqdn_host_aliases = $fqdn_host_aliases
-    $fqdn_ip              = $::ipaddress
   } else {
     $fqdn_ensure          = 'absent'
     $my_fqdn_host_aliases = []
-    $fqdn_ip              = $::ipaddress
   }
 
   Host {


### PR DESCRIPTION
Ubuntu 18.04, Puppet agent 6.0.2.

My Hiera:
```Yaml
hosts::export_host_resource: false
hosts::fqdn_ip: 127.0.1.1
hosts::fqdn_host_aliases:
  - "%{::hostname}"
  - "%{::hostname}.redactedaddomain.example.com"
```

My Puppet run:
```Shell
root@redactedhost:~# puppet agent -t
Notice: Local environment: 'production' doesn't match server specified node environment 'master', switching agent to 'master'.
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Retrieving locales
Info: Loading facts
Info: Caching catalog for redactedhost.example.com
Info: Applying configuration version '1539779194'
Notice: /Stage[main]/Cs_applications/Package[rubygems]/ensure: created
Notice: /Stage[main]/Cs_applications/Package[freerdp-x11]/ensure: created
Notice: /Stage[main]/Msktutil::Service/Exec[keytabperms]/returns: executed successfully
Notice: /Stage[main]/Cups::Server::Config/Exec[cups::papersize]/returns: executed successfully
Info: Class[Cups::Server::Config]: Scheduling refresh of Class[Cups::Server::Services]
Info: Class[Cups::Server::Services]: Scheduling refresh of Service[cups]
Notice: /Stage[main]/Cups::Server::Services/Service[cups]: Triggered 'refresh' from 1 event
Notice: /Stage[main]/Hosts/Host[redactedhost.ncl.ac.uk]/ip: ip changed '10.70.16.193' to '127.0.1.1'
Info: Computing checksum on file /etc/hosts
```

My /etc/hosts:
```Shell
root@redactedhost:~# cat /etc/hosts
# HEADER: This file was autogenerated at 2018-10-17 13:26:46 +0100
# HEADER: by puppet.  While it can still be managed manually, it
# HEADER: is definitely not recommended.
127.0.0.1	localhost.localdomain	localhost localhost4 localhost4.localdomain4
::1	localhost6.localdomain6	localhost6 localhost6.localdomain6
127.0.1.1	redactedhost.example.com	redactedhost redactedhost.redactedaddomain.example.com
```